### PR TITLE
Hosted hotspot connect message update.

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -313,7 +313,7 @@ export default {
       already_added:
         'You already added this hotspot to your wallet. Continue to the next screen to assert its location.',
       not_owned:
-        'You do not own this hotspot and cannot add it to your wallet.',
+        'It looks like you’re adding a hosted hotspot; you can connect to Wi-Fi but it will not show in your app.',
       label: 'CURRENT ADD HOTSPOT FEE (PAID IN DATA CREDITS)',
       help_link: 'What are Data Credits?',
       support_title: 'What are Data Credits?',


### PR DESCRIPTION
Small change to the message shown to a user setting up a hotspot they do not personally own. This flow is currently the only way (outside of Kent's unofficial hotspot utility) hotspot hosts can connect their hotspots to Wi-Fi without owner involvement, and the dialog is particularly disorienting to less technically inclined users. Preferably the dialog here would also be able to be closed not backed out of, as the latter intuitively indicates that the network connection did not succeed.